### PR TITLE
Fix default value for indexer on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Option | Description
 --- | ---
 client | A setting hash to build Elasticsearch client. More information you can find [here](https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/_configuration.html#_building_the_client_from_a_configuration_hash). By default the host is set to `localhost:9200`.
 update_mapping | The option that specifies whether to update a mapping automatically or not. By default it is set to `true`.
-indexer | Set to `single` for the single document indexing and to `bulk` for the bulk document indexing. By default is set to `true`.
+indexer | Set to `single` for the single document indexing and to `bulk` for the bulk document indexing. By default is set to `single`.
 
 Note, that if you use the bulk document indexing you'll probably want to change the chunk size, you can do that in the `config/scout.php` file.
 


### PR DESCRIPTION
Currently, the docs says that the default value for `indexer` config if `true`, but this isn't a valid value, and
the correct default value is `single` as you can see on https://github.com/babenkoivan/scout-elasticsearch-driver/blob/master/config/scout_elastic.php

I've fixed it on the docs.