### PR TITLE
Pagination have issue with race condition converting data object from array to object with keys

### DIFF
--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -218,7 +218,7 @@ class ElasticEngine extends Engine
             if (isset($models[$id])) {
                 return $models[$id];
             }
-        })->filter();
+        })->filter()->values();
     }
 
     public function getTotalCount($results)


### PR DESCRIPTION
When we have race condition with filtering values from elastic via eloquent query (elastic data is in process of deleting, eloquent data is already deleted), we have filter some collection values, which convert array collection (numeric keys) into associative one (string keys). this fix reset key namings to return collection state to numeric keys. Same solution you could find in default Algolia driver: 
vendor/laravel/scout/src/Engines/AlgoliaEngine.php:186