### PR TITLE
Restore array keys when an item is deleted from the elastic index.

### DIFF
--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -218,7 +218,7 @@ class ElasticEngine extends Engine
             if (isset($models[$id])) {
                 return $models[$id];
             }
-        })->filter();
+        })->filter()->values();
     }
 
     public function getTotalCount($results)


### PR DESCRIPTION
Hi,

I had a slight problem with the search driver. The scenario is as followed:

1. I fetch a list of items trough the search driver
2. I delete an item, it will be deleted from the database directly and a little bit later from the elastic index.
3. Meanwhile, before the elastic index has processed the delete, I fetch the list again. 
4. The list results the items, including the deleted item. Then it goes trough the map function (ElasticEngine.php). This function filters out the deleted item, so the item lists is correct. 

At the end of the map function it does a filter() on the collection. Which is great, because we want to lose the deleted item. But the array keys are not reset, which will break any javascript when the result is parsed to json. 

For example:
```
[0] => ...,
[1] => ...,
[2] => ...,
```
We delete key 1:
```
[0] => ...,
[2] => ...,
```

The solution will be to add a values() function to the filter() function in map. I suggest we change the map function in ElasticEngine.php from:
```
public function map($results, $model)
{
    if ($this->getTotalCount($results) == 0) {
        return Collection::make();
    }

    $ids = $this->mapIds($results);

    $modelKey = $model->getKeyName();

    $models = $model->whereIn($modelKey, $ids)
                    ->get()
                    ->keyBy($modelKey);

    return Collection::make($results['hits']['hits'])->map(function ($hit) use ($models) {
        $id = $hit['_id'];

        if (isset($models[$id])) {
            return $models[$id];
        }
    })->filter();
}
```
To: 
```
public function map($results, $model)
{
    if ($this->getTotalCount($results) == 0) {
        return Collection::make();
    }

    $ids = $this->mapIds($results);

    $modelKey = $model->getKeyName();

    $models = $model->whereIn($modelKey, $ids)
                    ->get()
                    ->keyBy($modelKey);

    return Collection::make($results['hits']['hits'])->map(function ($hit) use ($models) {
        $id = $hit['_id'];

        if (isset($models[$id])) {
            return $models[$id];
        }
    })->filter()->values();
}
```