### PR TITLE
Adds ability to perform more advanced sorting.

### DIFF
--- a/src/Builders/FilterBuilder.php
+++ b/src/Builders/FilterBuilder.php
@@ -371,6 +371,12 @@ class FilterBuilder extends Builder
      */
     public function orderBy($field, $direction = 'asc')
     {
+        //if we're passing an array, just add it to the builder
+        if (is_array($field)) {
+            $this->orders[] = $field;
+            return $this;
+        }
+
         $this->orders[] = [
             $field => strtolower($direction) == 'asc' ? 'asc' : 'desc'
         ];

--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -297,6 +297,11 @@ class ElasticEngine extends Engine
                 if (isset($models[$id])) {
                     $model = $models[$id];
 
+                    //add sort information to results for use
+                    if (isset($hit['sort'])) {
+                        $model->sortPayload = $hit['sort'];
+                    }
+
                     if (isset($hit['highlight'])) {
                         $model->highlight = new Highlight($hit['highlight']);
                     }


### PR DESCRIPTION
# Background
I needed to be able to sort based on distance with `geo_point` and get the distance returned with my model. The library already supports searching by this information, but not sorting (that I could see).

I modified to the `orderBy` method to allow passing of an array for the sort `field`, instead of just the field name and direction (see `$orderBy` below for an example). This successfully let me sort by the `geo_point` field.

Next, I modified the `map()` method to add the information that returns from the `_geo_distance` sort to your Eloquent model as a `sortPayload` property.

Reference: 
https://www.elastic.co/guide/en/elasticsearch/guide/current/sorting-by-distance.html


## Example

```
$geoPoint = [
        'lat' => '43.53297880',
        'lon' => '-96.73129820',
    ];

    $distance = '1mi';
    
    $orderBy = [
        '_geo_distance' => [
            'location' => $geoPoint,
            'order' => 'asc',
            'unit' => 'mi',
            'distance_type' => 'plane',
        ]
    ];

Listing::search('*')->whereGeoDistance('location', $geoPoint, $distance)->orderBy($orderBy)->get();

```

## Results

```
array:2 [▼
  0 => array:7 [▼
    "id" => 1
    "name" => "Kramer"
    "lat" => "42.53297880"
    "lon" => "-95.73129820"
    "created_at" => "2018-06-05 17:34:36"
    "updated_at" => "2018-06-05 17:34:36"
    "sortPayload" => array:1 [▼
      0 => 2.5084632731254E-6
    ]
  ]
  1 => array:7 [▼
    "id" => 2
    "name" => "EP HQ"
    "lat" => "44.54327940"
    "lon" => "-97.72791280"
    "created_at" => "2018-06-05 17:34:36"
    "updated_at" => "2018-06-05 17:34:36"
    "sortPayload" => array:1 [▼
      0 => 0.73162197868807
    ]
  ]
]```