### PR TITLE
`Count` doesn't need take any documents

### DIFF
--- a/src/Builders/FilterBuilder.php
+++ b/src/Builders/FilterBuilder.php
@@ -491,6 +491,7 @@ class FilterBuilder extends Builder
     public function count()
     {
         return $this
+            ->take(0)
             ->engine()
             ->count($this);
     }


### PR DESCRIPTION
set take 0, the result is default 10 documents, but count can be without any documents.