### PR TITLE
index => not_analyzed deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,7 @@ class MyModel extends Model
                 'type' => 'text',
                 'fields' => [
                     'raw' => [
-                        'type' => 'text',
-                        'index' => 'not_analyzed',
+                        'type' => 'text'
                     ]
                 ]
             ],


### PR DESCRIPTION
Hi,

Just a small change so that people are not encouraged to use deprecated **not_analyzed** index attribute value. You could replace it with **false** in your example but I don't think that would be of any help.

https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index.html

Thanks.

Xavier