### PR TITLE
Fix getKey check when ($model['id'] === 0)

### DIFF
--- a/src/Payloads/DocumentPayload.php
+++ b/src/Payloads/DocumentPayload.php
@@ -13,7 +13,7 @@ class DocumentPayload extends TypePayload
      */
     public function __construct(Model $model)
     {
-        if (!$model->getKey()) {
+        if ($model->getKey() === null) {
             throw new Exception(sprintf(
                 'The key value must be set to construct a payload for the %s instance.',
                 get_class($model)


### PR DESCRIPTION
I have inherited a project which has a row with an id of 0 which causes an exception to be thrown incorrectly.

Looking through $model->getKey() I noticed that it returns 'NULL' if a key doesn't exist but will return '(int) 0' if an 'id' key does exist with value of '(int) 0'.

'(int) 0' will evaluate as false even though it is in fact the correct value.