### PR TITLE
ignore highlight in `count` method

### DIFF
--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -89,6 +89,7 @@ class ElasticEngine extends Engine
 
         if ($builder instanceof SearchBuilder) {
             $searchRules = $builder->rules ?: $builder->model->getSearchRules();
+	        $highlight = !!($options['highlight'] ?? true);
 
             foreach ($searchRules as $rule) {
                 $payload = new TypePayload($builder->model);
@@ -101,7 +102,9 @@ class ElasticEngine extends Engine
 
                     if ($ruleEntity->isApplicable()) {
                         $payload->setIfNotEmpty('body.query.bool', $ruleEntity->buildQueryPayload());
-                        $payload->setIfNotEmpty('body.highlight', $ruleEntity->buildHighlightPayload());
+	                    if ($highlight) {
+		                    $payload->setIfNotEmpty('body.highlight', $ruleEntity->buildHighlightPayload());
+	                    }
                     } else {
                         continue;
                     }
@@ -226,7 +229,7 @@ class ElasticEngine extends Engine
         $count = 0;
 
         $this
-            ->buildSearchQueryPayloadCollection($builder)
+            ->buildSearchQueryPayloadCollection($builder, ['highlight' => false])
             ->each(function ($payload) use (&$count) {
                 $result = ElasticClient::count($payload);
 


### PR DESCRIPTION
Hello!
Elastic Search method api **_count** does not support param  **highlight**. And it should be ignored on invoke ElasticEngine->count()

[Docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html)

Version of ES:
![image](https://user-images.githubusercontent.com/7047662/45084936-24335a00-b108-11e8-8d57-b03d3aec183c.png)

Error:
![image](https://user-images.githubusercontent.com/7047662/45085021-547af880-b108-11e8-8ec5-db05470eac82.png)

