### PR TITLE
Check if the model its using soft deletes to enable soft deletes in the query builder

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -88,7 +88,7 @@ trait Searchable
      */
     public static function search($query, $callback = null)
     {
-        $softDelete = config('scout.soft_delete', false);
+        $softDelete = $this->usesSoftDelete() && config('scout.soft_delete', false);
 
         if ($query == '*') {
             return new FilterBuilder(new static, $callback, $softDelete);


### PR DESCRIPTION
Add an extra check to see if the query builder should use soft deletes, checking only for the config value lead to unexpected behaviour.

Please see #136 for a more detailed explanation.