### PR TITLE
Magic _ID support to enable multiple models in same index (post type support ES) 

### DIFF
--- a/config/scout_elastic.php
+++ b/config/scout_elastic.php
@@ -8,5 +8,6 @@ return [
     ],
     'update_mapping' => env('SCOUT_ELASTIC_UPDATE_MAPPING', true),
     'indexer' => env('SCOUT_ELASTIC_INDEXER', 'single'),
-    'document_refresh' => env('SCOUT_ELASTIC_DOCUMENT_REFRESH')
+    'document_refresh' => env('SCOUT_ELASTIC_DOCUMENT_REFRESH'),
+	'uses_tablename_prefix_as_doc_id' =>env('SCOUT_ELASTIC_USES_TABLENAME_PREFIX_AS_DOC_ID', true)
 ];

--- a/config/scout_elastic.php
+++ b/config/scout_elastic.php
@@ -9,5 +9,5 @@ return [
     'update_mapping' => env('SCOUT_ELASTIC_UPDATE_MAPPING', true),
     'indexer' => env('SCOUT_ELASTIC_INDEXER', 'single'),
     'document_refresh' => env('SCOUT_ELASTIC_DOCUMENT_REFRESH'),
-	'uses_tablename_prefix_as_doc_id' =>env('SCOUT_ELASTIC_USES_TABLENAME_PREFIX_AS_DOC_ID', true)
+	'uses_tablename_prefix_as_doc_id' =>env('SCOUT_ELASTIC_USES_TABLENAME_PREFIX_AS_DOC_ID', false)
 ];


### PR DESCRIPTION
Allows for multiple model types inside the same index, without using the deprecated “type” in ES 6.x

Syntax for _id → tablename_id
→ adding the _source record is recommended
→ Adds a config var to disable/enable the parsing

Please design your indexes carefully, there is a good reason why ES phases the type param. I use this magic id thing to allow certain low record count, simpel models to be indexed in the same index - who often have the same table structure.

This is my very first pull request :) give feedback if I forgot something
