### PR TITLE
Add extra operators for equality and inequality assertions.

### DIFF
--- a/src/Builders/FilterBuilder.php
+++ b/src/Builders/FilterBuilder.php
@@ -75,6 +75,8 @@ class FilterBuilder extends Builder
 
         switch ($operator) {
             case '=':
+            case '==':
+            case '===':
                 $this->wheres['must'][] = [
                     'term' => [
                         $field => $value
@@ -122,8 +124,9 @@ class FilterBuilder extends Builder
                 ];
                 break;
 
-            case '!=':
             case '<>':
+            case '!=':
+            case '!==':
                 $this->wheres['must_not'][] = [
                     'term' => [
                         $field => $value
@@ -326,7 +329,7 @@ class FilterBuilder extends Builder
 
         return $this;
     }
-    
+
     /**
      * @see https://www.elastic.co/guide/en/elasticsearch/guide/current/querying-geo-shapes.html Querying Geo Shapes
      *
@@ -346,7 +349,7 @@ class FilterBuilder extends Builder
 
         return $this;
     }
-    
+
     /**
      * @param string $field
      * @param string $direction

--- a/tests/Builders/FilterBuilderTest.php
+++ b/tests/Builders/FilterBuilderTest.php
@@ -42,11 +42,24 @@ class FilterBuilderTest extends AbstractTestCase
         );
     }
 
-    public function testWhereEq()
+    public function dataProviderTestWhereEq()
+    {
+        return [
+            ['='],
+            ['=='],
+            ['==='],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderTestWhereEq
+     * @param string $operator
+     */
+    public function testWhereEq($operator)
     {
         $builder = (new FilterBuilder($this->mockModel()))
             ->where('foo', 0)
-            ->where('bar', '=', 1);
+            ->where('bar', $operator, 1);
 
         $this->assertEquals(
             [
@@ -60,10 +73,23 @@ class FilterBuilderTest extends AbstractTestCase
         );
     }
 
-    public function testWhereNotEq()
+    public function dataProviderTestWhereNotEq()
+    {
+        return [
+            ['<>'],
+            ['!='],
+            ['!=='],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderTestWhereNotEq
+     * @param string $operator
+     */
+    public function testWhereNotEq($operator)
     {
         $builder = (new FilterBuilder($this->mockModel()))
-            ->where('foo', '!=', 'bar');
+            ->where('foo', $operator, 'bar');
 
         $this->assertEquals(
             [


### PR DESCRIPTION
Add extra operators for equality and inequality assertions.

This is motivated by:
https://github.com/laravel/framework/blob/046351856c4d6c91fe55c279763b1a821f9f33c4/src/Illuminate/Support/Collection.php#L624-L636