### PR TITLE
drop-index OwnClassIndexCinfigurator not found

### DIFF
--- a/src/Console/Features/RequiresIndexConfiguratorArgument.php
+++ b/src/Console/Features/RequiresIndexConfiguratorArgument.php
@@ -13,7 +13,7 @@ trait RequiresIndexConfiguratorArgument
      */
     protected function getIndexConfigurator()
     {
-        $configuratorClass = trim($this->argument('index-configurator'));
+        $configuratorClass = "\\App\\".trim($this->argument('index-configurator'));
 
         $configuratorInstance = new $configuratorClass;
 


### PR DESCRIPTION
Hi.

When try use `php artisan elastic:drop-index TutorialIndexConfigurator` get error below:

```
   Symfony\Component\Debug\Exception\FatalThrowableError  : Class 'TutorialIndexConfigurator' not found

  at /Users/abkrim/Sites/lowino/vendor/babenkoivan/scout-elasticsearch-driver/src/Console/Features/RequiresIndexConfiguratorArgument.php:19
    15|     protected function getIndexConfigurator()
    16|     {
    17|         $configuratorClass = trim($this->argument('index-configurator'));
    18| 
  > 19|         $configuratorInstance = new $configuratorClass;
    20| 
    21|         if (!($configuratorInstance instanceof IndexConfigurator)) {
    22|             throw new InvalidArgumentException(sprintf(
    23|                 'The class %s must extend %s.',

  Exception trace:

  1   ScoutElastic\Console\ElasticIndexDropCommand::getIndexConfigurator()
      /Users/abkrim/Sites/lowino/vendor/babenkoivan/scout-elasticsearch-driver/src/Console/ElasticIndexDropCommand.php:26

  2   ScoutElastic\Console\ElasticIndexDropCommand::handle()
      /Users/abkrim/Sites/lowino/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:29

```

Problem is new needs a Class with namespace App

Best regards.
