### PR TITLE
Ignore 404 errors when deleting non-searchable models

### DIFF
--- a/src/Indexers/BulkIndexer.php
+++ b/src/Indexers/BulkIndexer.php
@@ -64,7 +64,8 @@ class BulkIndexer implements IndexerInterface
 
         $models->each(function ($model) use ($bulkPayload) {
             $actionPayload = (new RawPayload())
-                ->set('delete._id', $model->getKey());
+                ->set('delete._id', $model->getKey())
+                ->set('ignore', 404);
 
             $bulkPayload->add('body', $actionPayload->get());
         });

--- a/src/Indexers/SingleIndexer.php
+++ b/src/Indexers/SingleIndexer.php
@@ -52,6 +52,7 @@ class SingleIndexer implements IndexerInterface
     {
         $models->each(function ($model) {
             $payload = (new DocumentPayload($model))
+                ->set('ignore', 404)
                 ->get();
 
             ElasticClient::delete($payload);


### PR DESCRIPTION
Closes #88

Ignores 404 errors when deleting non-searchable models. This enables usage of `shouldBeSearchable` without causing exceptions, and without the need for extra queries.

I wasn't able to test thouroughly, but according to Elasticsearch docs it should work.