### PR TITLE
Implement issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,32 +1,29 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: 🐛 Bug report
+about: Report a bug related to scout-elastic-driver. Please ensure you are using the latest version.
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
-
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-**Expected behavior**
-A clear and concise description of what you expected to happen.
-
-**Additional context**
-Add any other context about the problem here.
-
-**Environment**
-
 <!--
-  Please describe the versions used on the environment where the bug occured.
+Please fill up this template in order to help us to reproduce,
+investigate and possibly fix your bug report. Issues that doesn't
+follow this template will be closed.
 -->
 
-    Laravel Framework: ?
-    PHP: ?
-    Scout-elasticsearch-driver: ?
-    Elasticsearch: ?
+**Versions**
+
+- scout-elastic-driver: #.#.#
+- laravel/framwork: #.#.#
+- php: #.#.#
+- elasticsearch: #.#.#
+
+**Description**
+
+<!-- Describe the bug you are reporting. Try to do your best here -->
+
+**Steps to reproduce**
+
+<!--
+Describe the steps to reproduce the bug. Remember that if we can't reproduce,
+we will not be able to fix the issue. So this step is also very important.
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.
+
+**Environment**
+
+<!--
+  Please describe the versions used on the environment where the bug occured.
+-->
+
+    Laravel Framework: ?
+    PHP: ?
+    Scout-elasticsearch-driver: ?
+    Elasticsearch: ?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: 💡 Feature request
+about: Ask for features.
+
+---
+
+<!--
+Please fill up this template in order to help us to understand
+your feature request.
+-->
+
+**Short Description**
+
+<!-- Describe the feature you are requesting in a few words. Try to do your best here -->
+
+**Use cases**
+
+<!--
+Describe some sittuation that this is helpful.
+-->

--- a/.github/ISSUE_TEMPLATE/help_wanted.md
+++ b/.github/ISSUE_TEMPLATE/help_wanted.md
@@ -1,7 +1,21 @@
 ---
 name: "🧐 Help question"
-about: 'Please do not use this channel for help questions. Use [Stack Overflow](https://stackoverflow.com) instead.'
+about: 'Questions about usage of this package.'
 
 ---
 
-Issues using this template will be closed immediately. 
+<!--
+Use this template for questions about this package usage, they will receive the `help wanted`
+and `question` tags, and the community can help you here.
+
+Also, if the problem is related to the Elasticsearch itself, eg. index mapping, search rules
+and environment setup, please try to search first on the official elasticsearch docs and on
+Stack Overflow community:
+
+- https://stackoverflow.com/questions/tagged/elasticsearch
+- https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+
+If you decide to create your question here, please try do your best to explain your question,
+and if possible provide some code samples. When the question is answered, fell free to close
+the issue yourself.
+-->

--- a/.github/ISSUE_TEMPLATE/help_wanted.md
+++ b/.github/ISSUE_TEMPLATE/help_wanted.md
@@ -1,0 +1,7 @@
+---
+name: "🧐 Help question"
+about: 'Please do not use this channel for help questions. Use [Stack Overflow](https://stackoverflow.com) instead.'
+
+---
+
+Issues using this template will be closed immediately. 


### PR DESCRIPTION
In order to organize issues, I've created 3 issue templates:

1. Bug Report
2. Feature Request
3. Help Question

The Help Question one, is just to tell people to do not use this channel for ask help questions and tell them to use stack overflow instead.