### PR TITLE
Use getScoutKey instead of getKey to get the ID field

### DIFF
--- a/src/Indexers/BulkIndexer.php
+++ b/src/Indexers/BulkIndexer.php
@@ -43,7 +43,7 @@ class BulkIndexer implements IndexerInterface
             }
 
             $actionPayload = (new RawPayload())
-                ->set('index._id', $model->getKey());
+                ->set('index._id', $model->getScoutKey());
 
             $bulkPayload
                 ->add('body', $actionPayload->get())
@@ -64,7 +64,7 @@ class BulkIndexer implements IndexerInterface
 
         $models->each(function ($model) use ($bulkPayload) {
             $actionPayload = (new RawPayload())
-                ->set('delete._id', $model->getKey());
+                ->set('delete._id', $model->getScoutKey());
 
             $bulkPayload->add('body', $actionPayload->get());
         });

--- a/src/Payloads/DocumentPayload.php
+++ b/src/Payloads/DocumentPayload.php
@@ -16,7 +16,7 @@ class DocumentPayload extends TypePayload
      */
     public function __construct(Model $model)
     {
-        if ($model->getKey() === null) {
+        if ($model->getScoutKey() === null) {
             throw new Exception(sprintf(
                 'The key value must be set to construct a payload for the %s instance.',
                 get_class($model)
@@ -25,7 +25,7 @@ class DocumentPayload extends TypePayload
 
         parent::__construct($model);
 
-        $this->payload['id'] = $model->getKey();
+        $this->payload['id'] = $model->getScoutKey();
         $this->protectedKeys[] = 'id';
     }
 }

--- a/tests/Dependencies/Model.php
+++ b/tests/Dependencies/Model.php
@@ -19,6 +19,7 @@ trait Model
             $params['methods'] ?? [],
             [
                 'getKey',
+                'getScoutKey',
                 'trashed',
                 'searchableAs',
                 'toSearchableArray',
@@ -33,6 +34,10 @@ trait Model
 
         $mock
             ->method('getKey')
+            ->willReturn($params['key'] ?? 1);
+
+        $mock
+            ->method('getScoutKey')
             ->willReturn($params['key'] ?? 1);
 
         $mock


### PR DESCRIPTION
This will allow us to explicitly redefine which field we want to use as an ID without having to change the base method `getKey()`.

Given that `getScoutKey()` internally calls `getKey()` I see no reason for this to be an breaking issue with current projects.
 
All tests are passing.

Thank you and keep up the good work!
