### PR TITLE
trait doesn't boot in extended classes

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -26,17 +26,17 @@ trait Searchable
      *
      * @var bool
      */
-    private static $isSearchableTraitBooted = false;
+    protected static $isSearchableTraitBooted = false;
 
     public static function bootSearchable()
     {
-        if (self::$isSearchableTraitBooted) {
+        if (static::$isSearchableTraitBooted) {
             return;
         }
 
         self::bootScoutSearchable();
 
-        self::$isSearchableTraitBooted = true;
+        static::$isSearchableTraitBooted = true;
     }
 
     /**


### PR DESCRIPTION
please use this late static binding for $isSearchableTraitBooted