### PR TITLE
Allow BulkIndexer to load relations efficiently when called from a queue

### DIFF
--- a/src/Console/stubs/searchable_model.stub
+++ b/src/Console/stubs/searchable_model.stub
@@ -27,4 +27,11 @@ class DummyClass extends Model
     protected $mapping = [
         //
     ];
+
+    /**
+     * @var array
+     */
+    public $searchableRelations = [
+        //
+    ];
 }

--- a/src/Indexers/BulkIndexer.php
+++ b/src/Indexers/BulkIndexer.php
@@ -17,6 +17,7 @@ class BulkIndexer implements IndexerInterface
     {
         $model = $models->first();
         $indexConfigurator = $model->getIndexConfigurator();
+        $relations = $model->searchableRelations ?? [];
 
         $bulkPayload = new TypePayload($model);
 
@@ -28,7 +29,8 @@ class BulkIndexer implements IndexerInterface
             $bulkPayload->set('refresh', $documentRefresh);
         }
 
-        $models->each(function ($model) use ($bulkPayload) {
+        $models->loadMissing($relations)
+            ->each(function ($model) use ($bulkPayload) {
             if ($model::usesSoftDelete() && config('scout.soft_delete', false)) {
                 $model->pushSoftDeleteMetadata();
             }


### PR DESCRIPTION
Because Scout passes all models through MakeSerachable class when using a queue. The class uses the SerializesModels trait and any eager loaded relations will no longer be present when the queued job is run. 

Since these relations are gone, BulkIndexer causes a query for every model when it reaches toSearchableArray(). By adding loadMissing and passing in desired relations via a property on the model class loads relations for that chunk without adding cost to single threaded uses