### PR TITLE
Feature/allow disable db hydration

### DIFF
--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -295,24 +295,7 @@ class ElasticEngine extends Engine
             return Collection::make();
         }
 
-        $primaryKey = $model->getKeyName();
-
-        $columns = Arr::get($results, '_payload.body._source');
-
-        if (is_null($columns)) {
-            $columns = ['*'];
-        } else {
-            $columns[] = $primaryKey;
-        }
-
-        $ids = $this->mapIds($results)->all();
-
-        $query = $model::usesSoftDelete() ? $model->withTrashed() : $model->newQuery();
-
-        $models = $query
-            ->whereIn($primaryKey, $ids)
-            ->get($columns)
-            ->keyBy($primaryKey);
+        $models = $this->hydrateModels($model, $results);
 
         return Collection::make($results['hits']['hits'])
             ->map(function ($hit) use ($models) {
@@ -330,6 +313,49 @@ class ElasticEngine extends Engine
             })
             ->filter()
             ->values();
+    }
+
+    /**
+     * @param $model
+     * @param $results
+     * @return Collection
+     */
+    public function hydrateModels($model, $results)
+    {
+        // Hydrate models from elastic index
+        if ($model->databaseHydrate === false) {
+            $hits = collect($results['hits']['hits']);
+            $className = get_class($model);
+            $models = new Collection();
+
+            $hits->each(function($item, $key) use ($className, $model, $models) {
+                $attributes = $item['_source'];
+                $models->put($item['_id'], new $className($attributes));
+            });
+        }
+        // Hydrate models from database
+        else {
+            $primaryKey = $model->getKeyName();
+
+            $columns = Arr::get($results, '_payload.body._source');
+
+            if (is_null($columns)) {
+                $columns = ['*'];
+            } else {
+                $columns[] = $primaryKey;
+            }
+
+            $ids = $this->mapIds($results)->all();
+
+            $query = $model::usesSoftDelete() ? $model->withTrashed() : $model->newQuery();
+
+            $models = $query
+                ->whereIn($primaryKey, $ids)
+                ->get($columns)
+                ->keyBy($primaryKey);
+        }
+
+        return $models;
     }
 
     /**

--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -329,7 +329,7 @@ class ElasticEngine extends Engine
             $models = new Collection();
 
             $hits->each(function($item, $key) use ($className, $model, $models) {
-                $attributes = $item['_source'];
+                $attributes = Arr::get($item['_source'], $model->indexAttributesPrefix);
                 $models->put($item['_id'], new $className($attributes));
             });
         }


### PR DESCRIPTION
Two main features can be found in this pull:

1. handles model property (boolean) $databaseHydrate to add option to disable database data hydration

2. also in my use case in elasticsearch stored data attributes has some prefix, for example: user.user_id, user.scope, where "user" is prefix for all model attributes, model property (string) $indexAttributesPrefix allows to load this model attributes properly.
since ES 6.0 multiple index data types is not allowed, and indeces created since 6.0 most likely will not need this feature, but for indices created since ES 5.x this is needed for me and hope also will be handy for someone else