### PR TITLE
Quick fix that should allow for model scope methods built with the Il…

### DIFF
--- a/src/Builders/FilterBuilder.php
+++ b/src/Builders/FilterBuilder.php
@@ -560,4 +560,18 @@ class FilterBuilder extends Builder
             $this->wheres['must'][] = ['term' => ['__soft_deleted' => 1]];
         });
     }
+
+    /**
+     * Handle dynamic method calls into the method.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        $this->model->$method(...$parameters);
+    }
 }


### PR DESCRIPTION
…luminate\Database\Eloquent\Builder to be utilized in ElasticSearch queries, provided they only use methods available on the Scout Builder or any of its derivatives.

At the top of your model:
`
use ScoutElastic\Builders\SearchBuilder;;
`

A properly created scope method:
`
    public function scopeWherePublished(SearchBuilder $query)
    {
        return $query->where('published', true);
    }
`