### PR TITLE
Always run bootSearchable method

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -11,7 +11,6 @@ use Laravel\Scout\Searchable as SourceSearchable;
 trait Searchable
 {
     use SourceSearchable {
-        SourceSearchable::bootSearchable as sourceBootSearchable;
         SourceSearchable::getScoutKeyName as sourceGetScoutKeyName;
     }
 
@@ -21,29 +20,6 @@ trait Searchable
      * @var \ScoutElastic\Highlight|null
      */
     private $highlight = null;
-
-    /**
-     * Defines if the model is searchable.
-     *
-     * @var bool
-     */
-    protected static $isSearchableTraitBooted = false;
-
-    /**
-     * Boot the trait.
-     *
-     * @return void
-     */
-    public static function bootSearchable()
-    {
-        if (static::$isSearchableTraitBooted) {
-            return;
-        }
-
-        self::sourceBootSearchable();
-
-        static::$isSearchableTraitBooted = true;
-    }
 
     /**
      * Get the index configurator.


### PR DESCRIPTION
This PR adjusts the bootSearchable method to run each time the trait is used, which matches the behavior of the default Scout Seachable trait.

By only running this once, we risk issues observers or macros not being available that Scout requires. We were running into an issue with our tests where the `::searachable()` and `::unsearchable()` methods were not available on the Eloquent builder unless we ran the test using those methods before any other tests. This is due to the application being refreshed between tests, and since the `$isSearchableTraitBooted` stays `true`, this trait wasn't being booted again and thus the macros required by Scout weren't being loaded.

I'm sure there are other places where the current implementation could be causing issues, but the above example is just the one that we ran into.