### PR TITLE
Change Elasticsearch SDK version constraint to v7.3.* (Fixes #297)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "elasticsearch/elasticsearch": "^7.0",
+        "elasticsearch/elasticsearch": "7.3.*",
         "laravel/scout": "^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi,

This PR fixes the issue #297 caused by a breaking change on `elasticsearch/elasticsearch` v7.4.0.

IMO the elasticsearch package versioning is wrong since it introduces a breaking change in a minor version. :-1: 

To fix it, I've changed our constraints to use only v7.3.*

In the future we need to move away from types completely since ES 8 will remove it completely.