### PR TITLE
Allow elasticsearch/elasticsearch >= 7.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "elasticsearch/elasticsearch": "7.3.*",
+        "elasticsearch/elasticsearch": "^7.0 !=7.4.0",
         "laravel/scout": "^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Follow-up to #297. [elasticsearch/elasticsearch 7.4.1](https://github.com/elastic/elasticsearch-php/releases/tag/v7.4.1) has been released, which fixes the BC issues introduced in 7.4.0. Therefore, we only have to exclude the broken 7.4.0 version.

See https://github.com/ruflin/Elastica/pull/1715 for reference.