### PR TITLE
Fixed Laravel 6.8 conflict

### DIFF
--- a/src/Console/SearchableModelMakeCommand.php
+++ b/src/Console/SearchableModelMakeCommand.php
@@ -34,14 +34,14 @@ class SearchableModelMakeCommand extends ModelMakeCommand
 
         $options[] = [
             'index-configurator',
-            'i',
+            null,
             InputOption::VALUE_REQUIRED,
             'Specify the index configurator for the model. It\'ll be created if doesn\'t exist.',
         ];
 
         $options[] = [
             'search-rule',
-            's',
+            null,
             InputOption::VALUE_REQUIRED,
             'Specify the search rule for the model. It\'ll be created if doesn\'t exist.',
         ];


### PR DESCRIPTION
Artisan command for searchable model creating updated to fix conflict from new Laravel 6.8 version update.

Command aliases "i" and "s" removed from repository class.