### PR TITLE
Added min_score option

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,14 @@ App\MyModel::search('*')
     ->get();
 ```
 
+And filter out results with a score less than [min_score](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-min-score): 
+
+```php
+App\MyModel::search('sales')
+    ->minScore(1.0)
+    ->get();
+```
+
 At last, if you want to send a custom request, you can use the `searchRaw` method:
 
 ```php

--- a/src/Builders/FilterBuilder.php
+++ b/src/Builders/FilterBuilder.php
@@ -47,6 +47,13 @@ class FilterBuilder extends Builder
     public $select = [];
 
     /**
+     * The min_score parameter.
+     *
+     * @var string
+     */
+    public $minScore;
+
+    /**
      * FilterBuilder constructor.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -520,6 +527,19 @@ class FilterBuilder extends Builder
             $this->select,
             Arr::wrap($fields)
         );
+
+        return $this;
+    }
+
+    /**
+     * Set the min_score on the filter.
+     *
+     * @param  float  $score
+     * @return $this
+     */
+    public function minScore($score)
+    {
+        $this->minScore = $score;
 
         return $this;
     }

--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -138,6 +138,7 @@ class ElasticEngine extends Engine
                 ->setIfNotEmpty('body.sort', $builder->orders)
                 ->setIfNotEmpty('body.explain', $options['explain'] ?? null)
                 ->setIfNotEmpty('body.profile', $options['profile'] ?? null)
+                ->setIfNotEmpty('body.min_score', $builder->minScore)
                 ->setIfNotNull('body.from', $builder->offset)
                 ->setIfNotNull('body.size', $builder->limit);
 

--- a/tests/Builders/FilterBuilderTest.php
+++ b/tests/Builders/FilterBuilderTest.php
@@ -483,4 +483,22 @@ class FilterBuilderTest extends AbstractTestCase
             $builder->wheres
         );
     }
+
+    public function testMinScore()
+    {
+        $builder = (new FilterBuilder($this->mockModel()));
+
+        $this->assertSame(
+            null,
+            $builder->minScore
+        );
+
+        $builder = (new FilterBuilder($this->mockModel()))
+            ->minScore(0.5);
+
+        $this->assertSame(
+            0.5,
+            $builder->minScore
+        );
+    }
 }


### PR DESCRIPTION
Added support for [min_score](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-min-score).  Requested in #122 and #101.  Usage is:
```php
App\MyModel::search('sales')
    ->minScore(1.0)
    ->get();
```