### PR TITLE
PR that fixes locking issues with newer versions of elasticsearch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "elasticsearch/elasticsearch": ">=7.0 <7.4.0",
+        "elasticsearch/elasticsearch": ">=7.0",
         "laravel/scout": "^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
This closes this issue: https://github.com/babenkoivan/scout-elasticsearch-driver/issues/323

Please refer to that thread for more information, as the <7.4.0 is no longer relevant.