### PR TITLE
Ensure Eloquent\Collection returned after filtering

### DIFF
--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -314,7 +314,7 @@ class ElasticEngine extends Engine
             ->get($columns)
             ->keyBy($scoutKeyName);
 
-        return Collection::make($results['hits']['hits'])
+        $values = Collection::make($results['hits']['hits'])
             ->map(function ($hit) use ($models) {
                 $id = $hit['_id'];
 
@@ -330,6 +330,8 @@ class ElasticEngine extends Engine
             })
             ->filter()
             ->values();
+
+        return $values instanceof Collection ? $values : Collection::make($values);
     }
 
     /**


### PR DESCRIPTION
I encountered an error when the `FilterBuilder` tried to access [`Collection::load()`](https://github.com/babenkoivan/scout-elasticsearch-driver/blob/master/src/Builders/FilterBuilder.php#L483) on a Support Collection, and not an Eloquent Collection. This is related to #257.

I tracked it down locally and realised that I had indexed IDs, that did not exist in the database. When the [`ElasticEngine` maps the Eloquent Collection data](https://github.com/babenkoivan/scout-elasticsearch-driver/blob/master/src/ElasticEngine.php#L319), if a model was not found, `null` would be returned. If this happens, the Eloquent Collection is converted to a Support Collection, thus causing the error. The `Collection::filter()` method is called right after map to filter out the nulled values, but the collection has already been converted at this stage.

This PR will ensure the returned collection is an Eloquent Collection.