### PR TITLE
Allow specification of elements other than body

### DIFF
--- a/src/Indexers/SingleIndexer.php
+++ b/src/Indexers/SingleIndexer.php
@@ -19,9 +19,19 @@ class SingleIndexer implements IndexerInterface
                 $model->pushSoftDeleteMetadata();
             }
 
+            $scoutMetaBody = [];
+            $scoutMetaOther = [];
+            foreach ($model->scoutMetadata() as $k => $v) {
+                if (is_string($k) && substr($k, 0, 1) === '_') {
+                    $scoutMetaOther[substr($k, 1)] = $v;
+                } else {
+                    $scoutMetaBody[$k] = $v;
+                }
+            }
+
             $modelData = array_merge(
                 $model->toSearchableArray(),
-                $model->scoutMetadata()
+                $scoutMetaBody
             );
 
             if (empty($modelData)) {
@@ -32,6 +42,9 @@ class SingleIndexer implements IndexerInterface
 
             $payload = (new DocumentPayload($model))
                 ->set('body', $modelData);
+            foreach ($scoutMetaOther as $k => $v) {
+                $payload->set($k, $v);
+            }
 
             if (in_array(Migratable::class, class_uses_recursive($indexConfigurator))) {
                 $payload->useAlias('write');

--- a/tests/Dependencies/Model.php
+++ b/tests/Dependencies/Model.php
@@ -53,6 +53,10 @@ trait Model
             ->willReturn($params['searchable_array'] ?? []);
 
         $mock
+            ->method('scoutMetadata')
+            ->willReturn($params['scoutMetadata'] ?? []);
+
+        $mock
             ->method('getIndexConfigurator')
             ->willReturn($params['index_configurator'] ?? $this->mockIndexConfigurator());
 

--- a/tests/Indexers/AbstractIndexerTest.php
+++ b/tests/Indexers/AbstractIndexerTest.php
@@ -37,6 +37,14 @@ abstract class AbstractIndexerTest extends AbstractTestCase
                 'trashed' => false,
                 'searchable_array' => [],
             ]),
+            $this->mockModel([
+                'key' => 4,
+                'trashed' => false,
+                'scoutMetadata' => [
+                    'name' => 'bar',
+                    '_routing' => 'woo',
+                ],
+            ]),
         ]);
     }
 }

--- a/tests/Indexers/SingleIndexerTest.php
+++ b/tests/Indexers/SingleIndexerTest.php
@@ -32,6 +32,17 @@ class SingleIndexerTest extends AbstractIndexerTest
                 'body' => [
                     'name' => 'bar',
                 ],
+            ])
+            ->shouldReceive('index')
+            ->once()
+            ->with([
+                'index' => 'test',
+                'type' => 'test',
+                'id' => 4,
+                'body' => [
+                    'name' => 'bar',
+                ],
+                'routing' => 'woo',
             ]);
 
         (new SingleIndexer)
@@ -76,6 +87,18 @@ class SingleIndexerTest extends AbstractIndexerTest
                 'body' => [
                     '__soft_deleted' => 0,
                 ],
+            ])
+            ->shouldReceive('index')
+            ->once()
+            ->with([
+                'index' => 'test',
+                'type' => 'test',
+                'id' => 4,
+                'body' => [
+                    'name' => 'bar',
+                    '__soft_deleted' => 0,
+                ],
+                'routing' => 'woo',
             ]);
 
         (new SingleIndexer)
@@ -110,6 +133,17 @@ class SingleIndexerTest extends AbstractIndexerTest
                 'body' => [
                     'name' => 'bar',
                 ],
+            ])
+            ->shouldReceive('index')
+            ->once()
+            ->with([
+                'index' => 'test',
+                'type' => 'test',
+                'id' => 4,
+                'body' => [
+                    'name' => 'bar',
+                ],
+                'routing' => 'woo',
             ]);
 
         (new SingleIndexer)
@@ -147,6 +181,16 @@ class SingleIndexerTest extends AbstractIndexerTest
                 'index' => 'test',
                 'type' => 'test',
                 'id' => 3,
+                'client' => [
+                    'ignore' => 404,
+                ],
+            ])
+            ->shouldReceive('delete')
+            ->once()
+            ->with([
+                'index' => 'test',
+                'type' => 'test',
+                'id' => 4,
                 'client' => [
                     'ignore' => 404,
                 ],
@@ -191,6 +235,17 @@ class SingleIndexerTest extends AbstractIndexerTest
                 'index' => 'test',
                 'type' => 'test',
                 'id' => 3,
+                'refresh' => true,
+                'client' => [
+                    'ignore' => 404,
+                ],
+            ])
+            ->shouldReceive('delete')
+            ->once()
+            ->with([
+                'index' => 'test',
+                'type' => 'test',
+                'id' => 2,
                 'refresh' => true,
                 'client' => [
                     'ignore' => 404,


### PR DESCRIPTION
There are [some parameters](https://github.com/elastic/elasticsearch-php/blob/6c9c0a765f8b31c1d9f1a5af4de2f53fd7298e38/src/Elasticsearch/Client.php#L766-L785) that we can specify in `Elasticsearch\Client` but not in this library.
e.g. one of the strategies to improve performance is to limit the shards by specifying routing, but it cannot with this library.

This PR provides a way to specify these in case of using SingleIndexer.
I think that it is difficult to specify in the case of using BulkIndexer, so it do not support it at this time.

I welcome editing of this PR by maintainers.
Thanks.