### PR TITLE
Search Settings (Edit the body of the request)

### DIFF
--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -153,6 +153,12 @@ class ElasticEngine extends Engine
                 $payload->setIfNotEmpty($clauseKey, $clauseValue);
             }
 
+            $settings = $builder->model->getSearchSettings();
+            foreach ($settings as $setting => $value) {
+                $settingKey = 'body.'.$setting;
+                $payload->setIfNotEmpty($settingKey, $value);
+            }
+
             return $payload->get();
         });
     }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -81,7 +81,7 @@ trait Searchable
     public function getSearchSettings()
     {
         return isset($this->searchSettings) && count($this->searchSettings) > 0 ?
-            $this->searchSettings : array();
+            $this->searchSettings : [];
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -74,6 +74,17 @@ trait Searchable
     }
 
     /**
+     * Get the search rules.
+     *
+     * @return array
+     */
+    public function getSearchSettings()
+    {
+        return isset($this->searchSettings) && count($this->searchSettings) > 0 ?
+            $this->searchSettings : array();
+    }
+
+    /**
      * Execute the search.
      *
      * @param  string  $query


### PR DESCRIPTION
Adds the ability to add data into the body of each request set in the Seachable model.

eg: `protected $searchSettings = [ 'track_total_hits' => true, ];`