### PR TITLE
Silence notice thrown by php74 on array offset access of non-array types

### DIFF
--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -348,7 +348,7 @@ class ElasticEngine extends Engine
      */
     public function getTotalCount($results)
     {
-        return $results['hits']['total']['value'];
+        return $results['hits']['total']['value'] ?? 0;
     }
 
     /**


### PR DESCRIPTION
---
name: 🐛 Bug report -- 
about: PHP 7.4 Array Offset Access Throws out a Notice
---

**Versions**

- scout-elastic-driver: 6.8.5
- laravel/framwork: 5.8.38
- php: 7.4.7
- elasticsearch: 6.8.5

**Description**

When using laravel tinker, we tried the following command:

`Model::search('text')->get()`, and it outputs the following error message.

```
PHP Notice: Trying to access array offset on value of type int in <project_root>/.../src/ElasticEngine.php
```

**Simple Fix**

Just a one line change using the following syntax: `$not_array['key'] ?? 0`. This silences the error, enabling the code to execute normally and fall back to a normal value if the key is not found. 
