### PR TITLE
PHP 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
-        "elasticsearch/elasticsearch": ">=7.0 <7.4.0",
+        "php": "^7.1.|^8.0",
+        "elasticsearch/elasticsearch": ">=7.0 <=7.11.0",
         "laravel/scout": "^7.0|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.0|^8.0",
         "mockery/mockery": "^1.0"
     },
     "autoload": {

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class AbstractTestCase extends TestCase
 {
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class AbstractTestCase extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown() : void
     {
         parent::tearDown();
 

--- a/tests/ElasticEngineTest.php
+++ b/tests/ElasticEngineTest.php
@@ -20,7 +20,7 @@ class ElasticEngineTest extends AbstractTestCase
      */
     private $engine;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->engine = $this
             ->getMockBuilder(ElasticEngine::class)

--- a/tests/ElasticEngineTest.php
+++ b/tests/ElasticEngineTest.php
@@ -20,7 +20,7 @@ class ElasticEngineTest extends AbstractTestCase
      */
     private $engine;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->engine = $this
             ->getMockBuilder(ElasticEngine::class)

--- a/tests/Indexers/AbstractIndexerTest.php
+++ b/tests/Indexers/AbstractIndexerTest.php
@@ -15,7 +15,7 @@ abstract class AbstractIndexerTest extends AbstractTestCase
      */
     protected $models;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->models = new Collection([
             $this->mockModel([

--- a/tests/Indexers/AbstractIndexerTest.php
+++ b/tests/Indexers/AbstractIndexerTest.php
@@ -15,7 +15,7 @@ abstract class AbstractIndexerTest extends AbstractTestCase
      */
     protected $models;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->models = new Collection([
             $this->mockModel([


### PR DESCRIPTION
Hi,

https://github.com/elastic/elasticsearch-php has just released the new package for PHP8 support. I've updated the dependencies and fixed a couple things.

Thanks!