### PR TITLE
Add option to return ElasticSearch score

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,17 @@ $model = App\MyModel::search('sales')
 $model->sortPayload;
 ```
 
+And return the score assigned by ElasticSearch with the models:
+
+```php
+$model = App\MyModel::search('sales')
+    ->withScores()
+    ->get();
+
+// To retrieve the score, use model \`_score\` attribute:
+$model->_score;
+```
+
 
 
 At last, if you want to send a custom request, you can use the `searchRaw` method:

--- a/src/Builders/FilterBuilder.php
+++ b/src/Builders/FilterBuilder.php
@@ -56,7 +56,7 @@ class FilterBuilder extends Builder
     /**
      * Determines if the score should be returned with the model.
      *
-     * @var boolean - false
+     * @var bool - false
      */
     public $withScores = false;
 

--- a/src/Builders/FilterBuilder.php
+++ b/src/Builders/FilterBuilder.php
@@ -54,6 +54,13 @@ class FilterBuilder extends Builder
     public $minScore;
 
     /**
+     * Determines if the score should be returned with the model
+     *
+     * @var boolean - false
+     */
+    public $withScores = false;
+
+    /**
      * FilterBuilder constructor.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -589,6 +596,19 @@ class FilterBuilder extends Builder
     public function minScore($score)
     {
         $this->minScore = $score;
+
+        return $this;
+    }
+
+    /**
+     * Set the withScores property.
+     *
+     * @param  boolean  $score - true
+     * @return $this
+     */
+    public function withScores($withScores = true)
+    {
+        $this->withScores = $withScores;
 
         return $this;
     }

--- a/src/Builders/FilterBuilder.php
+++ b/src/Builders/FilterBuilder.php
@@ -54,7 +54,7 @@ class FilterBuilder extends Builder
     public $minScore;
 
     /**
-     * Determines if the score should be returned with the model
+     * Determines if the score should be returned with the model.
      *
      * @var boolean - false
      */
@@ -603,7 +603,7 @@ class FilterBuilder extends Builder
     /**
      * Set the withScores property.
      *
-     * @param  boolean  $score - true
+     * @param  bool  $withScores - true
      * @return $this
      */
     public function withScores($withScores = true)

--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -306,6 +306,8 @@ class ElasticEngine extends Engine
             $columns[] = $scoutKeyName;
         }
 
+        $withScores = $builder->withScores;
+
         $ids = $this->mapIds($results)->all();
 
         $query = $model::usesSoftDelete() ? $model->withTrashed() : $model->newQuery();
@@ -319,11 +321,15 @@ class ElasticEngine extends Engine
             ->keyBy($scoutKeyName);
 
         $values = Collection::make($results['hits']['hits'])
-            ->map(function ($hit) use ($models) {
+            ->map(function ($hit) use ($models, $withScores) {
                 $id = $hit['_id'];
 
                 if (isset($models[$id])) {
                     $model = $models[$id];
+
+                    if($withScores && isset($hit['_score'])) {
+                        $model->_score = $hit['_score'];
+                    }
 
                     if (isset($hit['highlight'])) {
                         $model->highlight = new Highlight($hit['highlight']);

--- a/src/ElasticEngine.php
+++ b/src/ElasticEngine.php
@@ -327,7 +327,7 @@ class ElasticEngine extends Engine
                 if (isset($models[$id])) {
                     $model = $models[$id];
 
-                    if($withScores && isset($hit['_score'])) {
+                    if ($withScores && isset($hit['_score'])) {
                         $model->_score = $hit['_score'];
                     }
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -15,11 +15,18 @@ trait Searchable
     }
 
     /**
-     * The highligths.
+     * The highlights.
      *
      * @var \ScoutElastic\Highlight|null
      */
     private $highlight = null;
+
+    /**
+     * The score returned from elasticsearch
+     *
+     * @var float|null
+     */
+    public $_score;
 
     /**
      * Get the index configurator.

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -22,7 +22,7 @@ trait Searchable
     private $highlight = null;
 
     /**
-     * The score returned from elasticsearch
+     * The score returned from elasticsearch.
      *
      * @var float|null
      */


### PR DESCRIPTION
When providing a set of results, you may want to return the score that ElasticSearch is providing for a result to allow the consumer to determine its validity. This change will allow the user to make a call while working with the builder that would assign the _score to the model after retrieval.

Fixes #158.