### PR TITLE
Adds match filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,9 @@ whereNotIn($field, $value) | whereNotIn('id', [1, 2, 3]) | Checks if a value isn
 whereBetween($field, $value) | whereBetween('price', [100, 200]) | Checks if a value is in a range.
 whereNotBetween($field, $value) | whereNotBetween('price', [100, 200]) | Checks if a value isn't in a range.
 whereExists($field) | whereExists('unemployed') | Checks if a value is defined.
-whereNotExists($field) | whereNotExists('unemployed') | Checks if a value isn't defined.  
+whereNotExists($field) | whereNotExists('unemployed') | Checks if a value isn't define.
+whereMatch($field, $value) | whereMatch('tags', 'travel') | Filters records matching exact value. [Here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-match-query.html) you can find more about syntax.
+whereNotMatch($field, $value) | whereNotMatch('tags', 'travel') | Filters records not matching exact value. [Here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-match-query.html) you can find more about syntax.
 whereRegexp($field, $value, $flags = 'ALL') | whereRegexp('name.raw', 'A.+') | Filters records according to a given regular expression. [Here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html#regexp-syntax) you can find more about syntax.
 whereGeoDistance($field, $value, $distance) | whereGeoDistance('location', [-70, 40], '1000m') | Filters records according to given point and distance from it. [Here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html) you can find more about syntax.
 whereGeoBoundingBox($field, array $value) | whereGeoBoundingBox('location', ['top_left' =>  [-74.1, 40.73], 'bottom_right' => [-71.12, 40.01]]) | Filters records within given boundings. [Here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html) you can find more about syntax.

--- a/src/Builders/FilterBuilder.php
+++ b/src/Builders/FilterBuilder.php
@@ -276,6 +276,42 @@ class FilterBuilder extends Builder
     }
 
     /**
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-match-query.html Match query
+     *
+     * @param string $field
+     * @param string $value
+     * @return $this
+     */
+    public function whereMatch($field, $value)
+    {
+        $this->wheres['must'][] = [
+            'match' => [
+                $field => $value,
+            ],
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-match-query.html Match query
+     *
+     * @param string $field
+     * @param string $value
+     * @return $this
+     */
+    public function whereNotMatch($field, $value)
+    {
+        $this->wheres['must_not'][] = [
+            'match' => [
+                $field => $value,
+            ],
+        ];
+
+        return $this;
+    }
+
+    /**
      * Add a whereRegexp condition.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html Regexp query


### PR DESCRIPTION
It is compatible with ES 6.x, and quite important.

PS: if you look in 7.x docs, the syntax is actually slightly changed, and will refuse it in 8.x (as a note for V4.x which still does ES communication with 6.x syntax.
Probably v4 could be both tested using ES 6 and 7. I do not find yet any justifiable differences for the purpose of this package.